### PR TITLE
Bug fixes

### DIFF
--- a/A8Manager.jucer
+++ b/A8Manager.jucer
@@ -2,7 +2,7 @@
 
 <JUCERPROJECT id="wWHbxR" name="A8Manager" projectType="guiapp" useAppConfig="0"
               addUsingNamespaceToJuceHeader="0" displaySplashScreen="0" jucerFormatVersion="1"
-              companyName="OmOhmProductions" cppLanguageStandard="17" version="2.3.1"
+              companyName="OmOhmProductions" cppLanguageStandard="17" version="2.3.2"
               companyWebsite="www.omohmproductions.com">
   <MAINGROUP id="JDgvjc" name="A8Manager">
     <GROUP id="{26A00EED-F319-636E-6162-8A113C6EE925}" name="Source">

--- a/Source/Assimil8or/Preset/PresetProperties.cpp
+++ b/Source/Assimil8or/Preset/PresetProperties.cpp
@@ -32,9 +32,8 @@ void PresetProperties::copyTreeProperties (juce::ValueTree sourcePresetPropertie
 
         for (auto zoneIndex { 0 }; zoneIndex < channelSource.getNumChildren (); ++zoneIndex)
         {
-            auto zoneSource { channelSource.getChild (zoneIndex) };
-            auto zoneDestination { channelDestination.getChild (zoneIndex) };
-            zoneDestination.copyPropertiesFrom (zoneSource, nullptr);
+            ZoneProperties zoneDestinationProperties (channelDestination.getChild (zoneIndex), ZoneProperties::WrapperType::owner, ZoneProperties::EnableCallbacks::no);
+            zoneDestinationProperties.copyFrom (channelSource.getChild (zoneIndex));
         }
     }
 }

--- a/Source/Assimil8or/Preset/ZoneProperties.cpp
+++ b/Source/Assimil8or/Preset/ZoneProperties.cpp
@@ -12,6 +12,8 @@ juce::ValueTree ZoneProperties::create (int id)
 void ZoneProperties::copyFrom (juce::ValueTree sourceVT)
 {
     ZoneProperties sourceZoneProperties (sourceVT, ZoneProperties::WrapperType::client, ZoneProperties::EnableCallbacks::no);
+    // the sample itself needs to be loaded first, as loading a sample resets the sample and loop points, which would overwrite and values that were already loaded by a raw copying of properties
+    // this issue arose because loopLength and loopStart load before sample, but generally speaking, we can't rely on the ordering of the properties
     setSample (sourceZoneProperties.getSample (), false);
     setLevelOffset (sourceZoneProperties.getLevelOffset (), false);
     setLoopLength (sourceZoneProperties.getLoopLength ().value_or (-1.0), false);

--- a/Source/GUI/Assimil8or/Editor/ChannelEditor.cpp
+++ b/Source/GUI/Assimil8or/Editor/ChannelEditor.cpp
@@ -704,7 +704,7 @@ void ChannelEditor::setupChannelComponents ()
 
     // REVERSE/SMOOTH
     setupButton (reverseButton, "REV", "Reverse", [this] () { reverseUiChanged (reverseButton.getToggleState ()); });
-    setupButton (spliceSmoothingButton, "SMOOTH", "SpliceSmoothing", [this] () { reverseUiChanged (spliceSmoothingButton.getToggleState ()); });
+    setupButton (spliceSmoothingButton, "SMOOTH", "SpliceSmoothing", [this] () { spliceSmoothingUiChanged (spliceSmoothingButton.getToggleState ()); });
 
     // PAN/MIX
     setupLabel (panMixLabel, "PAN/MIX", kLargeLabelSize, juce::Justification::centred);
@@ -770,7 +770,7 @@ void ChannelEditor::setupChannelComponents ()
     setupComboBox (autoTriggerComboBox, "AutoTrigger", [this] ()
     {
         const auto autoTrigger { autoTriggerComboBox.getSelectedId () == 2 };
-        attackFromCurrentUiChanged (autoTrigger);
+        autoTriggerUiChanged (autoTrigger);
     });
 
     // PLAY MODE

--- a/Source/GUI/Assimil8or/Editor/ZoneEditor.cpp
+++ b/Source/GUI/Assimil8or/Editor/ZoneEditor.cpp
@@ -772,22 +772,25 @@ void ZoneEditor::levelOffsetUiChanged (double levelOffset)
 void ZoneEditor::loopLengthDataChanged (std::optional<double> loopLength)
 {
     loopLengthTextEditor.setText (formatLoopLength (loopLength.value_or (static_cast<double> (sampleData.getLengthInSamples () - zoneProperties.getLoopStart ().value_or (0)))));
+    updateLoopPointsView ();
 }
 
 void ZoneEditor::loopLengthUiChanged (double loopLength)
 {
     zoneProperties.setLoopLength (loopLength, false);
+    updateLoopPointsView ();
 }
 
 void ZoneEditor::loopStartDataChanged (std::optional<int64_t> loopStart)
 {
     loopStartTextEditor.setText (juce::String (loopStart.value_or (0)));
-    loopLengthDataChanged (zoneProperties.getLoopLength ());
+    updateLoopPointsView ();
 }
 
 void ZoneEditor::loopStartUiChanged (int64_t  loopStart)
 {
     zoneProperties.setLoopStart (loopStart, false);
+    updateLoopPointsView ();
 }
 
 void ZoneEditor::minVoltageDataChanged (double minVoltage)


### PR DESCRIPTION
Fixed bug where Smooth button was updating the Reverse parameter. Fixed bug where the Trigger mode combobox was updating the Envelope 'Attack From' parameter. Fixed bug where updating the Loop points did not update the waveform display. Fixed bug where Loop points were getting reset to defaults when a Preset was loaded.