### PR TITLE
V2.3.3 branch

### DIFF
--- a/A8Manager.jucer
+++ b/A8Manager.jucer
@@ -2,7 +2,7 @@
 
 <JUCERPROJECT id="wWHbxR" name="A8Manager" projectType="guiapp" useAppConfig="0"
               addUsingNamespaceToJuceHeader="0" displaySplashScreen="0" jucerFormatVersion="1"
-              companyName="OmOhmProductions" cppLanguageStandard="17" version="2.3.2"
+              companyName="OmOhmProductions" cppLanguageStandard="17" version="2.3.3"
               companyWebsite="www.omohmproductions.com">
   <MAINGROUP id="JDgvjc" name="A8Manager">
     <GROUP id="{26A00EED-F319-636E-6162-8A113C6EE925}" name="Source">

--- a/Source/GUI/Assimil8or/Editor/Assimil8orEditorComponent.cpp
+++ b/Source/GUI/Assimil8or/Editor/Assimil8orEditorComponent.cpp
@@ -204,6 +204,7 @@ void Assimil8orEditorComponent::init (juce::ValueTree rootPropertiesVT)
         //dumpStacktrace (-1, [this] (juce::String logLine) { DebugLog ("Assimil8orEditorComponent", logLine); });
         samplePool.setFolder (juce::File (fileName).getParentDirectory ());
         audioPlayerProperties.setPlayState (AudioPlayerProperties::PlayState::stop, false);
+        channelTabs.setCurrentTabIndex (0);
     };
 
     directoryDataProperties.wrap (runtimeRootProperties.getValueTree (), DirectoryDataProperties::WrapperType::client, DirectoryDataProperties::EnableCallbacks::yes);

--- a/Source/GUI/Assimil8or/Editor/ChannelEditor.cpp
+++ b/Source/GUI/Assimil8or/Editor/ChannelEditor.cpp
@@ -1228,7 +1228,7 @@ void ChannelEditor::setupChannelPropertiesCallbacks ()
     channelProperties.onSpliceSmoothingChange = [this] (bool spliceSmoothing) { spliceSmoothingDataChanged (spliceSmoothing);  };
     channelProperties.onXfadeGroupChange = [this] (juce::String xfadeGroup) { xfadeGroupDataChanged (xfadeGroup);  };
     channelProperties.onZonesCVChange = [this] (juce::String zonesCV) { zonesCVDataChanged (zonesCV);  };
-    channelProperties.onZonesRTChange = [this] (int zonesRT) { loopModeDataChanged (zonesRT);  };
+    channelProperties.onZonesRTChange = [this] (int zonesRT) { zonesRTDataChanged (zonesRT);  };
 }
 
 void ChannelEditor::checkStereoRightOverlay ()


### PR DESCRIPTION
Fix bug where a change to the Zones Retrigger data would update the Loop Mode UI.
Fixed bug where loading a new preset would not reset the display to Channel 1.