### PR TITLE
Improvements, bug fixes, and portability

### DIFF
--- a/A8Manager.jucer
+++ b/A8Manager.jucer
@@ -375,14 +375,14 @@
         <CONFIGURATION isDebug="0" name="Release"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
-        <MODULEPATH id="juce_audio_basics" path="../../juce"/>
-        <MODULEPATH id="juce_audio_devices" path="../../juce"/>
-        <MODULEPATH id="juce_audio_formats" path="../../juce"/>
-        <MODULEPATH id="juce_core" path="../../juce"/>
-        <MODULEPATH id="juce_data_structures" path="../../juce"/>
-        <MODULEPATH id="juce_events" path="../../juce"/>
-        <MODULEPATH id="juce_graphics" path="../../juce"/>
-        <MODULEPATH id="juce_gui_basics" path="../../juce"/>
+        <MODULEPATH id="juce_audio_basics" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_devices" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_formats" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_core" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_data_structures" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_events" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_graphics" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_gui_basics" path="../JUCE/modules"/>
         <MODULEPATH id="juce_audio_utils" path="../JUCE/modules"/>
         <MODULEPATH id="juce_audio_processors" path="../JUCE/modules"/>
         <MODULEPATH id="juce_gui_extra" path="../JUCE/modules"/>
@@ -395,18 +395,18 @@
         <CONFIGURATION isDebug="0" name="Release"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
-        <MODULEPATH id="juce_audio_basics" path="C:\code\JUCE\modules"/>
-        <MODULEPATH id="juce_audio_devices" path="C:\code\JUCE\modules"/>
-        <MODULEPATH id="juce_audio_formats" path="C:\code\JUCE\modules"/>
-        <MODULEPATH id="juce_audio_processors" path="C:\code\JUCE\modules"/>
-        <MODULEPATH id="juce_audio_utils" path="C:\code\JUCE\modules"/>
-        <MODULEPATH id="juce_core" path="C:\code\JUCE\modules"/>
-        <MODULEPATH id="juce_data_structures" path="C:\code\JUCE\modules"/>
-        <MODULEPATH id="juce_dsp" path="C:\code\JUCE\modules"/>
-        <MODULEPATH id="juce_events" path="C:\code\JUCE\modules"/>
-        <MODULEPATH id="juce_graphics" path="C:\code\JUCE\modules"/>
-        <MODULEPATH id="juce_gui_basics" path="C:\code\JUCE\modules"/>
-        <MODULEPATH id="juce_gui_extra" path="C:\code\JUCE\modules"/>
+        <MODULEPATH id="juce_audio_basics" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_devices" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_formats" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_processors" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_utils" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_core" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_data_structures" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_dsp" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_events" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_graphics" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_gui_basics" path="../JUCE/modules"/>
+        <MODULEPATH id="juce_gui_extra" path="../JUCE/modules"/>
       </MODULEPATHS>
     </LINUX_MAKE>
   </EXPORTFORMATS>

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Windows and macOS builds available at: https://cpr2323.github.io/a8manager/index
 
 Currently requires JUCE version 7. The revision from 1/10/2024: 31dfb05ea3299176a416bf9258e030d04a099798
 
+The Projucer exporters expect the JUCE checkout to be next to this repository:
+
+```text
+parent-folder/
+├── A8Manager/
+└── JUCE/
+```
+
 # Windows
 
 There are no special steps to installing on Windows.

--- a/Source/Assimil8or/Assimil8orPreset.cpp
+++ b/Source/Assimil8or/Assimil8orPreset.cpp
@@ -156,6 +156,9 @@ void Assimil8orPreset::parse (juce::StringArray presetLines)
     parseErrorList.removeAllChildren (nullptr);
     parseErrorList.removeAllProperties (nullptr);
 
+    while (! undoActionsStack.empty ())
+        undoActionsStack.pop ();
+
     curActions = &globalActions;
     curPresetSection = {};
     channelProperties = {};
@@ -173,28 +176,43 @@ void Assimil8orPreset::parse (juce::StringArray presetLines)
         value = presetLine.fromFirstOccurrenceOf (":", false, false).trim ();
         const auto paramName { key.upToFirstOccurrenceOf (" ", false, false) };
 
-        auto keyFound { false };
-        while (! keyFound)
+        auto findActionMapContaining = [this, &paramName] () -> ActionMap*
         {
-            if (const auto action { curActions->find (paramName) }; action != curActions->end ())
+            auto actionMapToCheck { curActions };
+            while (actionMapToCheck != nullptr)
             {
-                action->second ();
-                keyFound = true;
+                if (actionMapToCheck->find (paramName) != actionMapToCheck->end ())
+                    return actionMapToCheck;
+
+                if (actionMapToCheck == &zoneActions)
+                    actionMapToCheck = &channelActions;
+                else if (actionMapToCheck == &channelActions)
+                    actionMapToCheck = &presetActions;
+                else if (actionMapToCheck == &presetActions)
+                    actionMapToCheck = &globalActions;
+                else
+                    actionMapToCheck = nullptr;
             }
-            else
+            return nullptr;
+        };
+
+        if (auto actionMap { findActionMapContaining () }; actionMap != nullptr)
+        {
+            while (curActions != actionMap)
             {
-                // if we can't find the key in the current action map, then let's do the first undo action, and try again
-                // undoActionsStack should have items to reset
                 jassert (! undoActionsStack.empty ());
-                // if we have no undo actions, we are in an invalid state 
                 if (undoActionsStack.empty ())
                     break;
+
                 auto undoAction { undoActionsStack.top () };
                 undoActionsStack.pop ();
                 undoAction ();
             }
+
+            if (curActions == actionMap)
+                actionMap->find (paramName)->second ();
         }
-        if (! keyFound)
+        else
         {
             const auto unknownParameterError { "unknown parameter: " + key };
             LogParsing (unknownParameterError);
@@ -226,7 +244,7 @@ juce::String Assimil8orPreset::getSectionName ()
 void Assimil8orPreset::checkCvInputAndAmountFormat (juce::String theKey, juce::String theValue)
 {
     const auto delimiterLocation { theValue.indexOfChar (0, ' ') };
-    if (delimiterLocation == 0)
+    if (delimiterLocation <= 0 || delimiterLocation >= theValue.length () - 1)
     {
         const auto parameterFormatError { juce::String ("value '") + theValue + "' for parameter '" + theKey + "' - incorrect format" };
         LogParsing (parameterFormatError);
@@ -234,7 +252,6 @@ void Assimil8orPreset::checkCvInputAndAmountFormat (juce::String theKey, juce::S
         newParseError.setProperty ("type", "ParameterFormatError", nullptr);
         newParseError.setProperty ("description", parameterFormatError, nullptr);
         parseErrorList.addChild (newParseError, -1, nullptr);
-        jassertfalse;
     }
 };
 

--- a/Source/Assimil8or/Audio/AudioManager.cpp
+++ b/Source/Assimil8or/Audio/AudioManager.cpp
@@ -212,8 +212,7 @@ void AudioManager::splitStereoIntoTwoMono (juce::File inputFile)
             juce::AudioBuffer<float> monoAudioBuffer;
             monoAudioBuffer.setSize (1, static_cast<int> (sampleFileReader->lengthInSamples), false, true, false);
 
-            auto monoWritePtr { monoAudioBuffer.getWritePointer (0) };
-            std::memcpy (monoWritePtr, monoReadPtr, sampleFileReader->lengthInSamples * (sampleFileReader->bitsPerSample / 8));
+            monoAudioBuffer.copyFrom (0, 0, monoReadPtr, static_cast<int> (sampleFileReader->lengthInSamples));
 
             // write mono audio buffer to new file
             const auto monoOutputFileName { inputFile.getFileNameWithoutExtension () + "-" + postFixChannelIndicator };

--- a/Source/Assimil8or/Preset/ChannelProperties.cpp
+++ b/Source/Assimil8or/Preset/ChannelProperties.cpp
@@ -91,16 +91,21 @@ void ChannelProperties::copyFrom (juce::ValueTree sourceVT)
 
 juce::String ChannelProperties::getCvInputAndValueString (juce::String cvInput, double value, int decimalPlaces)
 {
-    if (cvInput.startsWith ("CV"))
-        return "0" + cvInput.substring(3, 4) + " " + juce::String (value, decimalPlaces);
-    else
-        return cvInput + " " + juce::String (value, decimalPlaces);
+    return getNormalizedCvInput (cvInput) + " " + juce::String (value, decimalPlaces);
 }
 
 juce::String ChannelProperties::getCvInputAndValueString (CvInputAndAmount cvInputAndValue, int decimalPlaces)
 {
     const auto& [cvInput, value] { cvInputAndValue };
     return getCvInputAndValueString (cvInput, value, decimalPlaces);
+}
+
+juce::String ChannelProperties::getNormalizedCvInput (juce::String cvInput)
+{
+    if (cvInput.startsWithIgnoreCase ("CV ") && cvInput.length () >= 4)
+        return "0" + cvInput.substring (3, 4).toUpperCase ();
+
+    return cvInput;
 }
 
 CvInputAndAmount ChannelProperties::getCvInputAndValueFromString (juce::String cvInputAndValueString)
@@ -315,7 +320,7 @@ void ChannelProperties::setXfadeGroup (juce::String xfadeGroup, bool includeSelf
 
 void ChannelProperties::setZonesCV (juce::String zonesCV, bool includeSelfCallback)
 {
-    setValue (zonesCV, ZonesCVPropertyId, includeSelfCallback);
+    setValue (getNormalizedCvInput (zonesCV), ZonesCVPropertyId, includeSelfCallback);
 }
 
 void ChannelProperties::setZonesRT (int zonesRT, bool includeSelfCallback)

--- a/Source/Assimil8or/Preset/ChannelProperties.h
+++ b/Source/Assimil8or/Preset/ChannelProperties.h
@@ -160,6 +160,7 @@ public:
     static juce::String getCvInputAndValueString (juce::String cvInput, double value, int decimalPlaces);
     static juce::String getCvInputAndValueString (CvInputAndAmount cvInputAndValue, int decimalPlaces);
     static CvInputAndAmount getCvInputAndValueFromString (juce::String cvInputAndValueString);
+    static juce::String getNormalizedCvInput (juce::String cvInput);
     static bool isChannelPropertiesVT (juce::ValueTree valueTree);
 
     static inline const juce::Identifier ChannelTypeId { "Channel" };

--- a/Source/GUI/Assimil8or/Editor/CvInputComboBox.cpp
+++ b/Source/GUI/Assimil8or/Editor/CvInputComboBox.cpp
@@ -73,7 +73,18 @@ void CvInputComboBox::setSelectedItemText (juce::String cvInputString)
     }
     if (cvInputString.toLowerCase () != "off")
     {
-        jassert (juce::String ("012345678").containsChar (cvInputString [0]) && juce::String ("ABC").containsChar (cvInputString [1]));
+        if (cvInputString.startsWithIgnoreCase ("CV ") && cvInputString.length () >= 4)
+            cvInputString = "0" + cvInputString.substring (3, 4).toUpperCase ();
+
+        if (cvInputString.length () < 2 ||
+            ! juce::String ("012345678").containsChar (cvInputString [0]) ||
+            ! juce::String ("ABC").containsChar (cvInputString [1]))
+        {
+            jassertfalse;
+            cvInputComboBox.setSelectedId (1, juce::NotificationType::dontSendNotification);
+            return;
+        }
+
         itemId = 2 + ((cvInputString [0] - '0') * 3) + cvInputString [1] - 'A';
         jassert (itemId > 1 && itemId < 29);
     }

--- a/Source/GUI/Assimil8or/FileView/FileViewComponent.cpp
+++ b/Source/GUI/Assimil8or/FileView/FileViewComponent.cpp
@@ -606,7 +606,7 @@ void FileViewComponent::importSamples (const juce::StringArray& files)
 {
     auto errorDialog = [this] (juce::String message)
     {
-        juce::AlertWindow::showMessageBoxAsync (juce::AlertWindow::WarningIcon, "Conversion Failed", message, {}, nullptr,
+        juce::AlertWindow::showMessageBoxAsync (juce::AlertWindow::WarningIcon, "Import Failed", message, {}, nullptr,
                                                 juce::ModalCallbackFunction::create ([this] (int) {}));
     };
 
@@ -619,9 +619,11 @@ void FileViewComponent::importSamples (const juce::StringArray& files)
         if (auto reader { audioManager->getReaderFor (file) }; reader != nullptr)
         {
             auto destinationFile { juce::File (appProperties.getMostRecentFolder ()).getChildFile (file.getFileNameWithoutExtension ()).withFileExtension ("wav") };
-            auto destinationFileStream { std::make_unique<juce::FileOutputStream> (destinationFile) };
-            destinationFileStream->setPosition (0);
-            destinationFileStream->truncate ();
+            if (destinationFile.existsAsFile ())
+            {
+                errorDialog ("The file '" + destinationFile.getFileName () + "' already exists. Import was skipped.");
+                continue;
+            }
 
             auto sampleRate { reader->sampleRate };
             auto numChannels { reader->numChannels };
@@ -631,15 +633,28 @@ void FileViewComponent::importSamples (const juce::StringArray& files)
                 bitsPerSample = 8;
             else if (bitsPerSample > 24) // the wave writer supports int 8/16/24
                 bitsPerSample = 24;
-            jassert (numChannels != 0);
+            if (numChannels == 0)
+            {
+                errorDialog ("The file '" + file.getFileName () + "' contains no audio channels.");
+                continue;
+            }
             if (numChannels > 2)
                 numChannels = 2;
             if (reader->sampleRate > 192000)
             {
-                // we need to do sample rate conversion
-                jassertfalse;
+                errorDialog ("The sample rate of '" + file.getFileName () + "' exceeds 192 kHz.");
+                continue;
             }
 
+            juce::TemporaryFile temporaryDestination (destinationFile);
+            auto destinationFileStream { temporaryDestination.getFile ().createOutputStream () };
+            if (destinationFileStream == nullptr || destinationFileStream->failedToOpen ())
+            {
+                errorDialog ("Unable to create a temporary file for '" + destinationFile.getFileName () + "'.");
+                continue;
+            }
+
+            auto writeSucceeded { false };
             juce::WavAudioFormat wavAudioFormat;
             if (std::unique_ptr<juce::AudioFormatWriter> writer { wavAudioFormat.createWriterFor (destinationFileStream.get (),
                                                                   sampleRate, numChannels, bitsPerSample, {}, 0) }; writer != nullptr)
@@ -651,25 +666,28 @@ void FileViewComponent::importSamples (const juce::StringArray& files)
                 // TODO - two things
                 //   a) this needs to be done in a thread
                 //   b) we should locally read into a buffer and then write that, so we can display progress if needed
-                if (! writer->writeFromAudioReader (*reader.get (), 0, -1) == true)
-                {
-                    // failure to convert
-                    errorDialog ("Failure to write new file");
-                    jassertfalse;
-                }
+                writeSucceeded = writer->writeFromAudioReader (*reader.get (), 0, -1);
             }
             else
             {
                 //failure to create writer
-                errorDialog ("Failure to create writer");
-                jassertfalse;
+                errorDialog ("Failure to create a writer for '" + destinationFile.getFileName () + "'.");
+                continue;
             }
+
+            if (! writeSucceeded)
+            {
+                errorDialog ("Failure to write '" + destinationFile.getFileName () + "'.");
+                continue;
+            }
+
+            if (destinationFile.existsAsFile () || ! temporaryDestination.overwriteTargetFileWithTemporary ())
+                errorDialog ("Unable to complete the import of '" + destinationFile.getFileName () + "'.");
         }
         else
         {
             // failure to create reader
-            errorDialog ("Failure to create reader");
-            jassertfalse;
+            errorDialog ("Failure to read '" + file.getFileName () + "'.");
         }
     }
 }

--- a/Source/GUI/Assimil8or/PresetList/PresetListComponent.cpp
+++ b/Source/GUI/Assimil8or/PresetList/PresetListComponent.cpp
@@ -20,13 +20,17 @@ PresetListComponent::PresetListComponent ()
     showAllPresets.setToggleState (true, juce::NotificationType::dontSendNotification);
     showAllPresets.setButtonText ("Show All");
     showAllPresets.setTooltip ("Show all Presets, Show only existing presets");
-    showAllPresets.onClick = [this] () { checkPresetsThread.start (); };
+    showAllPresets.onClick = [this] ()
+    {
+        requestedShowAllPresets.store (showAllPresets.getToggleState ());
+        requestPresetCheck ();
+    };
     addAndMakeVisible (showAllPresets);
     addAndMakeVisible (presetListBox);
 
     checkPresetsThread.onThreadLoop = [this] ()
     {
-        checkPresets ();
+        checkPresets (requestedShowAllPresets.load ());
         return false;
     };
 }
@@ -42,16 +46,7 @@ void PresetListComponent::init (juce::ValueTree rootPropertiesVT)
     directoryDataProperties.onRootScanComplete = [this] ()
     {
         LogPresetList ("PresetListComponent::init - directoryDataProperties.onRootScanComplete");
-        if (! checkPresetsThread.isThreadRunning ())
-        {
-            LogPresetList ("PresetListComponent::init - directoryDataProperties.onRootScanComplete - starting thread");
-            checkPresetsThread.startThread ();
-        }
-        else
-        {
-            LogPresetList ("PresetListComponent::init - directoryDataProperties.onRootScanComplete - starting timer");
-            startTimer (1);
-        }
+        requestPresetCheck ();
     };
 //     directoryDataProperties.onStatusChange = [this] (DirectoryDataProperties::ScanStatus status)
 //     {
@@ -81,6 +76,20 @@ void PresetListComponent::init (juce::ValueTree rootPropertiesVT)
     presetProperties.wrap (presetManagerProperties.getPreset ("edit"), PresetProperties::WrapperType::client, PresetProperties::EnableCallbacks::yes);
 
     checkPresetsThread.startThread ();
+}
+
+void PresetListComponent::requestPresetCheck ()
+{
+    if (! checkPresetsThread.isThreadRunning ())
+    {
+        LogPresetList ("PresetListComponent::requestPresetCheck - starting thread");
+        checkPresetsThread.startThread ();
+    }
+    else
+    {
+        LogPresetList ("PresetListComponent::requestPresetCheck - starting timer");
+        startTimer (1);
+    }
 }
 
 void PresetListComponent::forEachPresetFile (std::function<bool (juce::File presetFile, int index)> presetFileCallback)
@@ -114,26 +123,22 @@ void PresetListComponent::forEachPresetFile (std::function<bool (juce::File pres
     });
 }
 
-void PresetListComponent::checkPresets ()
+void PresetListComponent::checkPresets (bool showAll)
 {
     WatchdogTimer timer;
     timer.start (100000);
 
     FolderProperties rootFolder (directoryDataProperties.getRootFolderVT (), FolderProperties::WrapperType::client, FolderProperties::EnableCallbacks::no);
-    currentFolder = juce::File (rootFolder.getName ());
-
-    const auto showAll { showAllPresets.getToggleState () };
+    const auto scannedFolder { juce::File (rootFolder.getName ()) };
+    PresetInfoList newPresetInfoList;
 
     // clear preset info list
-    for (auto curPresetInfoIndex { 0 }; curPresetInfoIndex < presetInfoList.size (); ++curPresetInfoIndex)
-        presetInfoList[curPresetInfoIndex] = { curPresetInfoIndex + 1, false, "" };
+    for (auto curPresetInfoIndex { 0 }; curPresetInfoIndex < newPresetInfoList.size (); ++curPresetInfoIndex)
+        newPresetInfoList [curPresetInfoIndex] = { curPresetInfoIndex + 1, false, "" };
 
-    if (showAll)
-        numPresets = kMaxPresets;
-    else
-        numPresets = 0;
+    auto newNumPresets { showAll ? kMaxPresets : 0 };
     auto inPresetList { false };
-    ValueTreeHelpers::forEachChild (directoryDataProperties.getRootFolderVT (), [this, &inPresetList, showAll] (juce::ValueTree child)
+    ValueTreeHelpers::forEachChild (directoryDataProperties.getRootFolderVT (), [&inPresetList, &newNumPresets, &newPresetInfoList, showAll] (juce::ValueTree child)
     {
         if (FileProperties::isFileVT (child))
         {
@@ -155,11 +160,11 @@ void PresetListComponent::checkPresets ()
                 presetName = thisPresetProperties.getName ();
 
                 if (showAll)
-                    presetInfoList [presetIndex] = { presetIndex + 1 , true, presetName };
+                    newPresetInfoList [presetIndex] = { presetIndex + 1 , true, presetName };
                 else
                 {
-                    presetInfoList [numPresets] = { presetIndex + 1, true, presetName };
-                    ++numPresets;
+                    newPresetInfoList [newNumPresets] = { presetIndex + 1, true, presetName };
+                    ++newNumPresets;
                 }
             }
             else
@@ -172,17 +177,27 @@ void PresetListComponent::checkPresets ()
         return true; // keep looking
     });
 
-    juce::MessageManager::callAsync ([this, newFolder = (currentFolder != previousFolder)] ()
+    juce::MessageManager::callAsync ([safeThis = juce::Component::SafePointer<PresetListComponent> (this),
+                                      scannedFolder,
+                                      newNumPresets,
+                                      newPresetInfoList = std::move (newPresetInfoList)] () mutable
     {
-        presetListBox.updateContent ();
+        if (safeThis == nullptr)
+            return;
+
+        const auto newFolder { scannedFolder != safeThis->previousFolder };
+        safeThis->currentFolder = scannedFolder;
+        safeThis->numPresets = newNumPresets;
+        safeThis->presetInfoList = std::move (newPresetInfoList);
+        safeThis->presetListBox.updateContent ();
         if (newFolder)
         {
-            presetListBox.scrollToEnsureRowIsOnscreen (0);
-            loadFirstPreset ();
+            safeThis->presetListBox.scrollToEnsureRowIsOnscreen (0);
+            safeThis->loadFirstPreset ();
         }
-        presetListBox.repaint ();
+        safeThis->presetListBox.repaint ();
+        safeThis->previousFolder = scannedFolder;
     });
-    previousFolder = currentFolder;
 
     //juce::Logger::outputDebugString ("PresetListComponent::checkPresets - elapsed time: " + juce::String (timer.getElapsedTime ()));
 }
@@ -300,7 +315,7 @@ void PresetListComponent::timerCallback ()
     if (! checkPresetsThread.isThreadRunning ())
     {
         LogPresetList ("PresetListComponent::timerCallback - starting thread, stopping timer");
-        checkPresetsThread.start ();
+        checkPresetsThread.startThread ();
         stopTimer ();
     }
     LogPresetList ("PresetListComponent::timerCallback - enter");

--- a/Source/GUI/Assimil8or/PresetList/PresetListComponent.h
+++ b/Source/GUI/Assimil8or/PresetList/PresetListComponent.h
@@ -19,6 +19,9 @@ public:
     std::function<void (std::function<void ()>, std::function<void ()>)> overwritePresetOrCancel;
 
 private:
+    using PresetInfo = std::tuple<int, bool, juce::String>;
+    using PresetInfoList = std::array<PresetInfo, kMaxPresets>;
+
     AppProperties appProperties;
     DirectoryDataProperties directoryDataProperties;
     PresetProperties presetProperties;
@@ -27,15 +30,16 @@ private:
 
     juce::ToggleButton showAllPresets { "Show All" };
     juce::ListBox presetListBox { {}, this };
-    std::array<std::tuple <int, bool, juce::String>, kMaxPresets> presetInfoList;
+    PresetInfoList presetInfoList {};
     int numPresets { kMaxPresets };
     juce::File currentFolder;
     juce::File previousFolder;
     int lastSelectedPresetIndex { -1 };
+    std::atomic<bool> requestedShowAllPresets { true };
     LambdaThread checkPresetsThread { "CheckPresetsThread", 100 };
 
     void copyPreset (int presetNumber);
-    void checkPresets ();
+    void checkPresets (bool showAll);
     void deletePreset (int presetNumber);
     void exportPreset (int presetNumber);
     juce::File getPresetFile (int presetNumber);
@@ -47,6 +51,7 @@ private:
     void loadPreset (juce::File presetFile);
     void movePresetUp (int row);
     void movePresetDown (int row);
+    void requestPresetCheck ();
     void swapPresets (int fromRow, int toRow);
     void pastePreset (int presetNumber);
 

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -21,7 +21,7 @@
 #include "Utility/ValueTreeMonitor.h"
 
 // used to add things like TEST, or ALPHA, or BETA, etc to the version number when displayed
-constexpr char* kVersionDecorator { "" };
+constexpr const char* kVersionDecorator { "" };
 
 // this requires the third party Melatonin Inspector be installed and added to the project
 // https://github.com/sudara/melatonin_inspector


### PR DESCRIPTION
## Summary

This PR improves runtime safety, preset parsing, CV handling, audio conversion, thread usage, and build portability.

### Changes

- Preserve parser scope when unknown preset parameters are encountered, allowing subsequent valid parameters to continue parsing.
- Reset parser state between parses and report malformed CV input/amount values.
- Normalize channel-local `CV A/B/C` labels to the preset-file representation `0A/0B/0C`, including `ZonesCV`.
- Correct stereo-to-mono splitting to copy the complete floating-point audio buffer.
- Make sample imports transactional using temporary files.
  - Existing destination files are no longer silently overwritten.
  - Failed conversions no longer leave truncated files.
  - Zero-channel and sample rates above 192 kHz are rejected with an error.
- Remove preset-list message-thread races.
  - Worker threads now build local results.
  - UI and shared list state are updated on the JUCE message thread.
  - Asynchronous updates use a lifetime-safe component pointer.
- Standardize Projucer module paths around a sibling `JUCE/` checkout and document the expected directory layout.
- Correct the version decorator’s string-literal constness.

### User-visible behavior

- Unknown preset parameters no longer prevent later valid parameters or sample references from loading.
- `CV A/B/C` selections save and reload consistently.
- Split stereo files retain complete left and right channel audio.
- Importing a sample whose destination already exists is skipped instead of overwriting it.
- Failed imports leave existing files untouched.

### Validation

- Full macOS Debug build completed successfully with JUCE 8.0.12.
- Parser/CV regression probe passed.
- Stereo split regression probe passed, including channel contents and output lengths.
- Projucer XML validation passed.
- `git diff --check` passed.

The existing JUCE audio-writer API was retained for compatibility with the project’s documented JUCE 7 target; this PR does not require migration to JUCE 8.